### PR TITLE
Update to 0.25.1

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,2 @@
+upload_channel:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
-    - mkdir pytest-temp
+    - mkdir pytest-temp  # [win]
     - pytest woodwork/tests --basetemp=pytest-temp  # [win]
     # docker-py has an exact pinning for pywin32 that cause pip check to fail.
     - pip check  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,12 @@ build:
   number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  patches:                        # [win]
+    - remove-absolute-path.patch  # [win]
 
 requirements:
+  build:                          # [win]
+    - m2-patch                    # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,10 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
+    # Hard coded paths cause a few tests to break on Windows.
     - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_read_file.py"  # [win]
-    - pip check
+    # docker-py has an exact pinning for pywin32 that cause pip check to fail.
+    - pip check  # [not win]
 
 about:
   doc_url: https://woodwork.alteryx.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
     - woodwork
     - woodwork.tests
   requires:
+    - pip
     - boto3 >=1.10.45
     - moto >=3.0.7
     - pyarrow >=4.0.1
@@ -56,8 +57,12 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Woodwork provides a common typing namespace for using your existing DataFrames in Featuretools, EvalML, and general ML.
-
+  summary: Woodwork is a Python library that provides robust methods for managing and communicating data typing information.
+  description: |
+    Woodwork provides a common typing namespace for using your existing DataFrames in Featuretools,
+    EvalML, and general ML. A Woodwork DataFrame stores the physical, logical, and semantic data
+    types present in the data. In addition, it can store metadata about the data, allowing you to
+    store specific information you might need for your application.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
-    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_concat.py"  # [win]
+    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_read_file.py"  # [win]
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,36 @@
-{% set version = "0.21.2" %}
-
+{% set name = "woodwork" %}
+{% set version = "0.25.1" %}
 
 package:
-  name: woodwork
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/w/woodwork/woodwork-{{ version }}.tar.gz
-  sha256: 01eb8c7fc01240bea2329d45ee5a2b2a016c7e060199e82b5aac262efad183b8
+  url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
+  sha256: 73cb38e09229216cb7cbbaf2e4352b34d6e40ac44bf774c17e94a9047c7e98e3
 
 build:
   entry_points:
     - woodwork = woodwork.__main__:cli
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8.*
+    - python
+    - setuptools >=61.0.0
+    - wheel
   run:
-    - importlib-resources >=5.10.0
-    - numpy >=1.21.0
-    - pandas !=1.4.2, >=1.4.0
-    - python >=3.8.*
+    - importlib_resources >=5.10.0
+    - numpy >=1.22.0,<1.25.0
+    - pandas >=1.4.3
+    - python
     - python-dateutil >=2.8.1
     - scikit-learn >=0.22
-    - scipy >=1.4.0
+    - scipy >=1.10.0
+
 test:
   imports:
     - woodwork
@@ -36,9 +39,9 @@ test:
     - boto3 >=1.10.45
     - moto >=3.0.7
     - pyarrow >=4.0.1
-    - pytest ==7.0.1
-    - pytest-cov ==2.10.1
-    - pytest-xdist ==2.1.0
+    - pytest >=7.0.1
+    - pytest-cov >=2.10.1
+    - pytest-xdist >=2.1.0
     - smart_open >=5.0.0
   source_files:
     - woodwork/tests/*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
-    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py"  # [win]
+    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_concat.py"  # [win]
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ test:
     - woodwork.tests
   requires:
     - pip
+# Skip tests on s390x; missing moto and pyarrow
+{% if not s390x %}
     - boto3 >=1.10.45
     - moto >=3.0.7
     - pyarrow >=4.0.1
@@ -46,8 +48,9 @@ test:
     - smart_open >=5.0.0
   source_files:
     - woodwork/tests/*
+{% endif %}
   commands:
-    - pytest woodwork/tests
+    - pytest woodwork/tests  # [not s390x]
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,8 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
-    # Hard coded paths cause a few tests to break on Windows.
-    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_read_file.py"  # [win]
+    - mkdir pytest-temp
+    - pytest woodwork/tests --basetemp=pytest-temp  # [win]
     # docker-py has an exact pinning for pywin32 that cause pip check to fail.
     - pip check  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,8 @@ test:
 {% endif %}
   commands:
     - pytest woodwork/tests  # [not (s390x or win)]
-    - mkdir pytest-temp  # [win]
-    - pytest woodwork/tests --basetemp=pytest-temp  # [win]
+    # pytest tmpdir fixture causing broken tests on Windows.
+    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py" --ignore "woodwork/tests/utils/test_read_file.py"  # [win]
     # docker-py has an exact pinning for pywin32 that cause pip check to fail.
     - pip check  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
   sha256: 73cb38e09229216cb7cbbaf2e4352b34d6e40ac44bf774c17e94a9047c7e98e3
+  patches:                        # [win]
+    - remove-absolute-path.patch  # [win]
 
 build:
   entry_points:
@@ -15,8 +17,6 @@ build:
   number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  patches:                        # [win]
-    - remove-absolute-path.patch  # [win]
 
 requirements:
   build:                          # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,8 @@ test:
     - woodwork/tests/*
 {% endif %}
   commands:
-    - pytest woodwork/tests  # [not s390x]
+    - pytest woodwork/tests  # [not (s390x or win)]
+    - pytest woodwork/tests --ignore "woodwork/tests/accessor/test_serialization.py"  # [win]
     - pip check
 
 about:

--- a/recipe/remove-absolute-path.patch
+++ b/recipe/remove-absolute-path.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index e3245ba..b1ed461 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -118,7 +118,7 @@ namespaces = true
+ "*" = [
+     "* __pycache__",
+     "*.py[co]",
+-    "/docs/*"
++    "./docs/*"
+ ]
+ 
+ [tool.setuptools.dynamic]


### PR DESCRIPTION
[Upstream repo](https://github.com/alteryx/woodwork/tree/v0.25.1)

- Uploading to Snowflake channel
- The URL mentioned by the linter is correct and reachable. Not sure why it's getting a 403.
- Added patch to fix absolute file path in `pyproject.toml` on Windows.
- A few test files seem to have hard coded file paths that break on Windows. Skipping them accordingly.
- Skipping pip check on Windows due to an issue with `docker-py`: https://anaconda.atlassian.net/browse/PKG-3226