### PR TITLE
bump up build number, remove abs.yaml

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   entry_points:
     - woodwork = woodwork.__main__:cli
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 


### PR DESCRIPTION
woodwork 0.25.1
bump up build number and remove abs.yaml in order to push to defaults