### PR TITLE
Remove docs from install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,12 @@ source:
 build:
   entry_points:
     - woodwork = woodwork.__main__:cli
-  number: 1
+  number: 2
   skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script:
+    - del /s /f /q docs  # [win]
+    - rm -rf docs  # [not win]
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:                          # [win]


### PR DESCRIPTION
Rebuild to remove the docs from the installation. This creates ClobberWarning warnings.

It is unclear if this goes to snowflake or not considering it's on both defaults and snowflake channels.