### PR TITLE
woodwork 0.31.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "woodwork" %}
-{% set version = "0.25.1" %}
+{% set version = "0.31.0" %}
 
 package:
   name: {{ name }}
@@ -7,19 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
-  sha256: 73cb38e09229216cb7cbbaf2e4352b34d6e40ac44bf774c17e94a9047c7e98e3
+  sha256: 6ef82af1d5b6525b02efe6417c574c810cfdcc606cb266bd0d7fb17a1d066b67
   patches:                        # [win]
     - remove-absolute-path.patch  # [win]
 
 build:
-  entry_points:
-    - woodwork = woodwork.__main__:cli
-  number: 2
-  skip: True  # [py<38]
+  number: 0
+  skip: True  # [py<39]
   script:
     - del /s /f /q docs  # [win]
     - rm -rf docs  # [not win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - woodwork = woodwork.__main__:cli
 
 requirements:
   build:                          # [win]
@@ -31,11 +31,11 @@ requirements:
     - wheel
   run:
     - importlib_resources >=5.10.0
-    - numpy >=1.22.0,<1.25.0
-    - pandas >=1.4.3
+    - numpy >=1.25.0
+    - pandas >=2.0.0
     - python
-    - python-dateutil >=2.8.1
-    - scikit-learn >=0.22
+    - python-dateutil >=2.8.2
+    - scikit-learn >=1.1.0
     - scipy >=1.10.0
 
 test:
@@ -46,11 +46,10 @@ test:
     - pip
 # Skip tests on s390x; missing moto and pyarrow
 {% if not s390x %}
-    - boto3 >=1.10.45
-    - moto >=3.0.7
-    - pyarrow >=4.0.1
+    - boto3 >=1.34.32
+    - moto >=5.0.0
+    - pyarrow >=14.0.1
     - pytest >=7.0.1
-    - pytest-cov >=2.10.1
     - pytest-xdist >=2.1.0
     - smart_open >=5.0.0
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,9 @@ requirements:
     - wheel
   run:
     - importlib_resources >=5.10.0
-    - numpy >=1.25.0
+    # restrict numpy <2.0.0 until the next release,
+    # see https://github.com/alteryx/woodwork/pull/1869
+    - numpy >=1.25.0,<2.0.0
     - pandas >=2.0.0
     - python
     - python-dateutil >=2.8.2


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4688](https://anaconda.atlassian.net/browse/PKG-4688) 
- [Upstream repository](https://github.com/alteryx/woodwork/tree/v0.31.0)
- Requirements: https://github.com/alteryx/woodwork/blob/v0.31.0/pyproject.toml

### Explanation of changes:

- Reset the build number to `0.`
- Update pinnings in `run` and `test/requires`


[PKG-4688]: https://anaconda.atlassian.net/browse/PKG-4688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ