### PR TITLE
Build 0.31.0 for python 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,14 @@ source:
     - remove-absolute-path.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   script:
     - del /s /f /q docs  # [win]
     - rm -rf docs  # [not win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - woodwork = woodwork.__main__:cli
-  # numpy <2 is not available for py313
-  skip: True  # [py<39 or py>312]
+  skip: True  # [py<39]
 
 requirements:
   build:                          # [win]
@@ -32,9 +31,7 @@ requirements:
     - wheel
   run:
     - importlib_resources >=5.10.0
-    # restrict numpy <2.0.0 until the next release,
-    # see https://github.com/alteryx/woodwork/pull/1869
-    - numpy >=1.25.0,<2.0.0
+    - numpy >=1.25.0
     - pandas >=2.0.0
     - python
     - python-dateutil >=2.8.2
@@ -65,8 +62,8 @@ test:
   commands:
     # docker-py has an exact pinning for pywin32 that cause pip check to fail.
     - pip check  # [not win]
-    - pytest --pyargs woodwork.tests {{ deselect_tests }}  # [not win]
-
+    - pytest --pyargs woodwork.tests {{ deselect_tests }}  # [not win and py<313]
+    - pytest --pyargs woodwork.tests {{ deselect_tests }}  --deselect=type_system/test_ltype_inference.py # [not win and py313]
   requires:
     - pip
     - boto3 >=1.34.32

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,7 @@ test:
   commands:
     # docker-py has an exact pinning for pywin32 that cause pip check to fail.
     - pip check  # [not win]
-    - pytest --pyargs woodwork.tests {{ deselect_tests }}  # [not win and py<313]
-    - pytest --pyargs woodwork.tests {{ deselect_tests }}  --deselect=type_system/test_ltype_inference.py # [not win and py313]
+    - pytest --pyargs woodwork.tests {{ deselect_tests }}  --deselect=type_system/test_ltype_inference.py # [not win]
   requires:
     - pip
     - boto3 >=1.34.32


### PR DESCRIPTION
woodwork 0.31.0 

**Destination channel:** main

### Links

- [PKG-10293]
- dev_url:        https://github.com/alteryx/woodwork/tree/v0.31.0
- conda_forge:    https://github.com/conda-forge/woodwork-feedstock
- pypi:           https://pypi.org/project/woodwork/0.31.0
- pypi inspector: https://inspector.pypi.io/project/woodwork/0.31.0

### Explanation of changes:

- build for python 3.13

I removed restriction for numpy according to https://github.com/alteryx/woodwork/commit/a32ac361ce3f251bc5801a4bb3c43e3eff3ffff2

[PKG-10293]: https://anaconda.atlassian.net/browse/PKG-10293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ